### PR TITLE
fix: Remove conflicting react-router dependency and use npm ci

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router": "^6.20.1",
     "react-router-dom": "^6.20.1",
     "lucide-react": "^0.294.0"
   },

--- a/frontend/render.yaml
+++ b/frontend/render.yaml
@@ -1,7 +1,7 @@
 # Render deployment configuration for QuickVendor Frontend
 name: quickvendor-frontend
 type: static
-buildCommand: rm -rf node_modules package-lock.json && npm install && npm run build
+buildCommand: rm -rf node_modules && npm ci && npm run build
 staticPublishPath: dist
 
 # Environment variables to set in Render dashboard:


### PR DESCRIPTION
Issue: React Router module resolution error in Render deployment
- Error: Failed to resolve entry for package 'react-router'
- Caused by explicit react-router dependency conflicting with react-router-dom

Solution:
- ✅ Remove explicit react-router dependency (react-router-dom includes it)
- ✅ Use npm ci instead of npm install for reproducible builds
- ✅ Keep package-lock.json for consistent dependency resolution
- ✅ Maintain clean node_modules removal in build command

Local test: ✅ Build successful
- vite v5.0.8 building for production...
- ✓ 1377 modules transformed
- ✓ built in 2.27s

Dependencies cleaned:
- react-router-dom: ✅ (sufficient for routing)
- react-router: ❌ (removed - was causing conflicts)

Ready for stable Render deployment!