### PR TITLE
fix: Update Render build command to force clean Vite installation

### DIFF
--- a/frontend/render.yaml
+++ b/frontend/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: quickvendor-frontend
     runtime: static
-    buildCommand: npm install && npm run build
+    buildCommand: rm -rf node_modules package-lock.json && npm install && npm run build
     staticPublishPath: ./dist
     headers:
       - path: /*


### PR DESCRIPTION
Issue: Vite internal module error persists in Render deployment
- Error: Cannot find module 'dep-uAHLeuC6.js' from vite/dist/node/chunks/
- Render was using cached/corrupted Vite installation

Solution:
- ✅ Updated render.yaml buildCommand to include clean installation
- ✅ Force removal of node_modules and package-lock.json before install
- ✅ Maintain updated services format with proper headers

Build Command:
- From: 'npm install && npm run build'
- To: 'rm -rf node_modules package-lock.json && npm install && npm run build'

Local verification: ✅ Build successful
- vite v5.0.8 building for production...
- ✓ 1377 modules transformed
- ✓ built in 3.90s
- Built with vendor code splitting and optimization

This should resolve the Vite module corruption issue on Render!