### PR TITLE
fix: Use npm ci for faster, more reliable builds

### DIFF
--- a/frontend/render.yaml
+++ b/frontend/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: quickvendor-frontend
     runtime: static
-    buildCommand: rm -rf node_modules package-lock.json && npm install && npm run build
+    buildCommand: rm -rf node_modules && npm ci && npm run build
     staticPublishPath: ./dist
     headers:
       - path: /*


### PR DESCRIPTION
- Changed from 'npm install' to 'npm ci' in Render build command
- Keep package-lock.json for deterministic dependency resolution
- npm ci is faster and more reliable for CI/CD environments
- Only remove node_modules, preserve lock file

Build command: rm -rf node_modules && npm ci && npm run build

Local test: ✅ Build successful in 4.19s