### PR TITLE
🔧 Fix backend API URL for production deployment

### DIFF
--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,5 +1,5 @@
 // API Configuration for QuickVendor Frontend
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || (import.meta.env.MODE === 'production' ? 'https://quickvendor-backend.onrender.com' : 'http://localhost:8000');
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || (import.meta.env.MODE === 'production' ? 'https://quickvendor-app.onrender.com' : 'http://localhost:8000');
 
 // Export the configured API base URL
 export { API_BASE_URL };


### PR DESCRIPTION
- Updated API_BASE_URL from quickvendor-backend.onrender.com to quickvendor-app.onrender.com
- This matches the actual deployed backend URL
- Should resolve auth endpoint 404 errors
- SPA routing (_redirects) already configured

✅ Backend API calls should now work correctly