### PR TITLE
🔧 Fix API endpoint for user authentication

### DIFF
--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -22,7 +22,7 @@ export const authenticatedApiCall = async (endpoint: string, options: RequestIni
 
 // New functions
 export const getAuthenticatedUser = async (token: string) => {
-  const response = await authenticatedApiCall('/api/auth/user', { headers: { 'Authorization': `Bearer ${token}` }, });
+  const response = await authenticatedApiCall('/api/users/me', { headers: { 'Authorization': `Bearer ${token}` }, });
   if (response.ok) {
     return response.json();
   }


### PR DESCRIPTION
- Changed /api/auth/user to /api/users/me to match backend implementation
- Backend has /api/users/me endpoint, not /api/auth/user
- This should resolve the 404 errors when fetching user data
- Verified backend endpoints via OpenAPI spec

✅ API calls should now use correct endpoints