### PR TITLE
Fix S3 image upload issue

### DIFF
--- a/backend/S3_UPLOAD_FIX.md
+++ b/backend/S3_UPLOAD_FIX.md
@@ -1,0 +1,104 @@
+# S3 Upload Issue Resolution
+
+## Problem Summary
+Product images were not being uploaded to AWS S3 bucket despite having S3 credentials configured.
+
+## Root Causes Identified
+
+### 1. Missing boto3 Package
+- **Issue**: The Python AWS SDK (`boto3`) was not installed in the virtual environment
+- **Impact**: The S3Manager couldn't initialize, causing all uploads to fall back to local storage
+- **Solution**: Installed boto3 in the virtual environment
+  ```bash
+  source .venv/bin/activate
+  pip install boto3
+  ```
+
+### 2. ACL Configuration Mismatch
+- **Issue**: The code was trying to set `'ACL': 'public-read'` during upload
+- **Impact**: S3 rejected uploads with error "AccessControlListNotSupported - The bucket does not allow ACLs"
+- **Reason**: Your S3 bucket has ACLs disabled (which is AWS best practice for security)
+- **Solution**: Removed the ACL parameter from the upload code in `app/services/s3_manager.py`
+
+## Changes Made
+
+### File: `app/services/s3_manager.py`
+```python
+# Before (line 207):
+'ACL': 'public-read',  # This was causing the error
+
+# After:
+# Removed ACL parameter - public access is managed through bucket policy instead
+```
+
+## Current Configuration Status
+
+✅ **AWS S3 Credentials**: Configured correctly
+- Region: eu-north-1
+- Bucket: quickvendor-products
+
+✅ **Bucket Policy**: Already configured for public read access
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PublicReadGetObject",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::quickvendor-products/qv-products-img/*"
+        }
+    ]
+}
+```
+
+✅ **boto3**: Installed in virtual environment
+
+✅ **S3Manager**: Now properly initialized and working
+
+## Testing Confirmation
+
+Successfully tested upload to S3:
+- Test file uploaded to: `qv-products-img/test_20250812_090121/20250812_080121_3b9ae173.png`
+- Public URL format: `https://quickvendor-products.s3.eu-north-1.amazonaws.com/qv-products-img/{product_id}/{filename}`
+
+## Next Steps for Product Creation
+
+When you create new products with images, they will now:
+1. Automatically upload to S3 bucket
+2. Store the public S3 URL in the database
+3. Images will be accessible via the public URLs
+
+## Important Notes
+
+1. **Always run the backend with the virtual environment activated**:
+   ```bash
+   source .venv/bin/activate
+   uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+   ```
+
+2. **S3 Storage Structure**:
+   - Images are stored in: `qv-products-img/{product_id}/{unique_filename}`
+   - Each product's images are organized in separate folders
+
+3. **Fallback Behavior**:
+   - If S3 upload fails, the system falls back to local storage
+   - Check logs for any S3 upload failures
+
+## Verification Commands
+
+To verify S3 is working:
+```bash
+# Test S3 connection
+python3 test_s3_connection.py
+
+# Test S3Manager initialization
+python3 test_s3_manager.py
+
+# Test actual upload
+python3 test_product_creation.py
+```
+
+---
+*Issue resolved on: 2025-08-12*

--- a/backend/app/services/s3_manager.py
+++ b/backend/app/services/s3_manager.py
@@ -199,12 +199,13 @@ class S3Manager:
             # Upload file to S3
             logger.info(f"Uploading image to S3: {s3_key}")
             
+            # Note: ACL is not set here because the bucket has ACLs disabled
+            # Public access is managed through bucket policy instead
             self.s3_client.upload_fileobj(
                 file_content,
                 self.bucket_name,
                 s3_key,
                 ExtraArgs={
-                    'ACL': 'public-read',  # Make the image publicly readable
                     'ContentType': content_type,
                     'ContentDisposition': 'inline',  # Display in browser instead of download
                     'CacheControl': 'max-age=31536000',  # Cache for 1 year


### PR DESCRIPTION
- Remove ACL parameter from S3 upload as bucket has ACLs disabled
- Bucket uses policy-based public access instead of ACLs
- Add documentation for S3 upload fix
- Images now successfully upload to S3 bucket