### PR TITLE
Add store customization features: custom name and banner image

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,14 +1,18 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 import logging
+import re
+from io import BytesIO
+from typing import Dict, Any
 
 from app.core.database import get_db
 from app.core.security import get_password_hash
 from app.core.sentry import set_user_context, add_breadcrumb, capture_message_with_context
 from app.models.user import User
-from app.schemas.user import UserRegisterRequest, UserRegisterResponse, ErrorResponse, UserProfile
+from app.schemas.user import UserRegisterRequest, UserRegisterResponse, ErrorResponse, UserProfile, UpdateStoreRequest
 from app.api.deps import get_current_user
+from app.services.s3_manager import get_s3_manager
 
 router = APIRouter()
 
@@ -126,5 +130,192 @@ async def get_current_user_profile(
         id=current_user.id,
         email=current_user.email,
         whatsapp_number=current_user.whatsapp_number,
-        store_url=None  # Frontend will generate the correct URL
+        store_url=None,  # Frontend will generate the correct URL
+        store_name=current_user.store_name,
+        store_slug=current_user.store_slug,
+        banner_url=current_user.banner_url
     )
+
+
+@router.put("/me/store", response_model=UserProfile)
+async def update_store_info(
+    store_data: UpdateStoreRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Update store information (name and slug).
+    
+    - **store_name**: Display name for the store (3-100 characters)
+    - **store_slug**: URL-friendly identifier (3-50 characters, lowercase, numbers and hyphens only)
+    
+    The store_slug must be unique and will be used in the store URL.
+    """
+    try:
+        # Update store name if provided
+        if store_data.store_name is not None:
+            current_user.store_name = store_data.store_name
+        
+        # Update and validate store slug if provided
+        if store_data.store_slug is not None:
+            # Check if slug is already taken by another user
+            existing_slug = db.query(User).filter(
+                User.store_slug == store_data.store_slug,
+                User.id != current_user.id
+            ).first()
+            
+            if existing_slug:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="This store URL is already taken. Please choose another."
+                )
+            
+            current_user.store_slug = store_data.store_slug
+        
+        db.commit()
+        db.refresh(current_user)
+        
+        logging.info(f"Store info updated for user {current_user.email}: name={current_user.store_name}, slug={current_user.store_slug}")
+        
+        return UserProfile(
+            id=current_user.id,
+            email=current_user.email,
+            whatsapp_number=current_user.whatsapp_number,
+            store_url=None,
+            store_name=current_user.store_name,
+            store_slug=current_user.store_slug,
+            banner_url=current_user.banner_url
+        )
+        
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This store URL is already taken."
+        )
+    except Exception as e:
+        db.rollback()
+        logging.error(f"Failed to update store info: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to update store information"
+        )
+
+
+@router.post("/me/banner", response_model=Dict[str, Any])
+async def upload_store_banner(
+    banner: UploadFile = File(..., description="Banner image file"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Upload a banner image for the store.
+    
+    - **banner**: Image file (JPEG, PNG, GIF, WebP, BMP)
+    - Maximum file size: 5MB
+    - Recommended dimensions: 1200x300 pixels
+    
+    The banner will be uploaded to S3 and the URL will be saved to the user's profile.
+    """
+    # Check file size (limit to 5MB for banners)
+    MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB in bytes
+    file_content = await banner.read()
+    file_size = len(file_content)
+    
+    if file_size > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File size exceeds maximum allowed size of 5MB. Your file: {file_size / (1024*1024):.2f}MB"
+        )
+    
+    # Reset file pointer for S3 upload
+    file_like = BytesIO(file_content)
+    
+    try:
+        # Initialize S3 manager
+        s3_manager = get_s3_manager()
+        
+        if not s3_manager.is_s3_configured():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Image storage service is not available. Please try again later."
+            )
+        
+        # Upload to S3 with a special path for banners
+        upload_result = await s3_manager.upload_store_banner(
+            file_content=file_like,
+            filename=banner.filename,
+            user_id=current_user.id,
+            content_type=banner.content_type
+        )
+        
+        # Delete old banner if exists
+        if current_user.banner_url and current_user.banner_url.startswith("https://"):
+            # Extract S3 key from URL and delete old banner
+            try:
+                old_key = current_user.banner_url.split(".amazonaws.com/")[-1]
+                await s3_manager.delete_product_image(old_key)
+            except:
+                pass  # Ignore errors when deleting old banner
+        
+        # Update user with new banner URL
+        current_user.banner_url = upload_result["url"]
+        db.commit()
+        db.refresh(current_user)
+        
+        logging.info(f"Banner uploaded successfully for user {current_user.email}")
+        
+        return {
+            "message": "Banner uploaded successfully",
+            "banner_url": upload_result["url"],
+            "filename": upload_result["filename"]
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logging.error(f"Failed to upload banner: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to upload banner image. Please try again later."
+        )
+
+
+@router.delete("/me/banner", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_store_banner(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Delete the store banner image.
+    """
+    if not current_user.banner_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No banner image found"
+        )
+    
+    try:
+        # Delete from S3 if it's an S3 URL
+        if current_user.banner_url.startswith("https://"):
+            s3_manager = get_s3_manager()
+            if s3_manager.is_s3_configured():
+                try:
+                    s3_key = current_user.banner_url.split(".amazonaws.com/")[-1]
+                    await s3_manager.delete_product_image(s3_key)
+                except:
+                    pass  # Ignore S3 deletion errors
+        
+        # Clear banner URL from database
+        current_user.banner_url = None
+        db.commit()
+        
+        logging.info(f"Banner deleted for user {current_user.email}")
+        
+    except Exception as e:
+        db.rollback()
+        logging.error(f"Failed to delete banner: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete banner image"
+        )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -13,6 +13,9 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     whatsapp_number = Column(String, nullable=False)
     store_url = Column(String, unique=True, nullable=True)
+    store_name = Column(String, nullable=True)  # Custom store name
+    store_slug = Column(String, unique=True, index=True, nullable=True)  # URL-friendly store identifier
+    banner_url = Column(String, nullable=True)  # S3 URL for store banner image
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/schemas/storefront.py
+++ b/backend/app/schemas/storefront.py
@@ -28,12 +28,16 @@ class StorefrontResponse(BaseModel):
     vendor_name: str
     whatsapp_number: str
     products: List[PublicProductResponse]
+    banner_url: str | None = None
+    store_slug: str | None = None
 
     class Config:
         json_schema_extra = {
             "example": {
                 "vendor_name": "Awesome Wears",
                 "whatsapp_number": "2348012345678",
+                "banner_url": "https://s3.amazonaws.com/store-banners/banner.jpg",
+                "store_slug": "awesome-wears",
                 "products": [
                     {
                         "id": "product_uuid_1",

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -41,5 +41,22 @@ class UserProfile(BaseModel):
     email: str
     whatsapp_number: str
     store_url: str | None = None
+    store_name: str | None = None
+    store_slug: str | None = None
+    banner_url: str | None = None
 
     model_config = {"from_attributes": True}
+
+
+class UpdateStoreRequest(BaseModel):
+    store_name: Optional[str] = Field(None, min_length=3, max_length=100)
+    store_slug: Optional[str] = Field(None, min_length=3, max_length=50, pattern="^[a-z0-9-]+$")
+    
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "store_name": "John's Fashion Store",
+                "store_slug": "johns-fashion"
+            }
+        }
+    }

--- a/backend/migrations/add_store_customization.py
+++ b/backend/migrations/add_store_customization.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Migration script to add store customization fields to users table
+"""
+import os
+import sys
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+import logging
+
+# Load environment variables
+load_dotenv()
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def run_migration():
+    """Add store_name, store_slug, and banner_url columns to users table."""
+    
+    DATABASE_URL = os.getenv('DATABASE_URL')
+    if not DATABASE_URL:
+        logger.error("DATABASE_URL not found in environment variables")
+        return False
+    
+    engine = create_engine(DATABASE_URL)
+    is_sqlite = 'sqlite' in DATABASE_URL.lower()
+    
+    try:
+        with engine.connect() as conn:
+            # Check if columns already exist
+            existing_columns = []
+            
+            if is_sqlite:
+                # SQLite approach
+                result = conn.execute(text("PRAGMA table_info(users)"))
+                existing_columns = [row[1] for row in result]  # column name is at index 1
+            else:
+                # PostgreSQL approach
+                result = conn.execute(text("""
+                    SELECT column_name 
+                    FROM information_schema.columns 
+                    WHERE table_name='users' 
+                    AND column_name IN ('store_name', 'store_slug', 'banner_url')
+                """))
+                existing_columns = [row[0] for row in result]
+            
+            # Add store_name column if it doesn't exist
+            if 'store_name' not in existing_columns:
+                logger.info("Adding store_name column...")
+                conn.execute(text("""
+                    ALTER TABLE users 
+                    ADD COLUMN store_name VARCHAR(255)
+                """))
+                conn.commit()
+                logger.info("✓ store_name column added")
+            else:
+                logger.info("store_name column already exists")
+            
+            # Add store_slug column if it doesn't exist
+            if 'store_slug' not in existing_columns:
+                logger.info("Adding store_slug column...")
+                
+                if is_sqlite:
+                    # SQLite doesn't support adding UNIQUE in ALTER TABLE
+                    conn.execute(text("""
+                        ALTER TABLE users 
+                        ADD COLUMN store_slug VARCHAR(100)
+                    """))
+                    conn.commit()
+                    
+                    # Create unique index instead
+                    conn.execute(text("""
+                        CREATE UNIQUE INDEX IF NOT EXISTS idx_users_store_slug_unique 
+                        ON users(store_slug)
+                    """))
+                    conn.commit()
+                else:
+                    # PostgreSQL supports UNIQUE in ALTER TABLE
+                    conn.execute(text("""
+                        ALTER TABLE users 
+                        ADD COLUMN store_slug VARCHAR(100) UNIQUE
+                    """))
+                    conn.commit()
+                    
+                    # Create index for faster lookups
+                    conn.execute(text("""
+                        CREATE INDEX IF NOT EXISTS idx_users_store_slug 
+                        ON users(store_slug)
+                    """))
+                    conn.commit()
+                
+                logger.info("✓ store_slug column added with unique constraint and index")
+            else:
+                logger.info("store_slug column already exists")
+            
+            # Add banner_url column if it doesn't exist
+            if 'banner_url' not in existing_columns:
+                logger.info("Adding banner_url column...")
+                conn.execute(text("""
+                    ALTER TABLE users 
+                    ADD COLUMN banner_url TEXT
+                """))
+                conn.commit()
+                logger.info("✓ banner_url column added")
+            else:
+                logger.info("banner_url column already exists")
+            
+            logger.info("Migration completed successfully!")
+            return True
+            
+    except Exception as e:
+        logger.error(f"Migration failed: {str(e)}")
+        return False
+
+if __name__ == "__main__":
+    success = run_migration()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
- Added store_name, store_slug, and banner_url fields to User model
- Vendors can now set custom store name and URL slug
- Vendors can upload banner images to S3 for their store page
- Store API now uses store_slug for custom URLs (backwards compatible)
- Added endpoints: PUT /api/users/me/store, POST /api/users/me/banner
- Created database migration script for new columns
- Banner images are stored in S3 under store-banners/ folder

This allows vendors to:
1. Give their store a custom name instead of using email
2. Set a custom URL slug (e.g., /store/johns-fashion)
3. Upload an attractive banner image for their storefront
4. Make their store more professional and engaging